### PR TITLE
Change link's href to a jsdelivr one and removed "sub_filter on;"

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,11 +5,8 @@ This is a dark skin for the Deluge WebUI to use with [Organizr](https://github.c
 
 ## Installation
 Deluge requires a [subfilter](http://nginx.org/en/docs/http/ngx_http_sub_module.html) to use. All you have to do is include the following into your reverse proxy block for Deluge.
+
 ```nginx
 proxy_set_header Accept-Encoding "";
-sub_filter
-'</head>'
-'<link rel="stylesheet" type="text/css" href="https://halianelf.github.io/Deluge-Dark/deluge.css">
-</head>';
-sub_filter_once on;
+sub_filter '</head>' '<link rel="stylesheet" type="text/css" href="https://cdn.jsdelivr.net/gh/HalianElf/Deluge-Dark@master/deluge.css"></head>';
 ```


### PR DESCRIPTION
I've changed the URL from the github.io one to a jsdelivr one since jsdelivr is a CDN, and I've removed `sub_filter on;` since it isn't required and won't work in the current versions of nginx.